### PR TITLE
Add queue-scoped tasks and registry support

### DIFF
--- a/pgtq/task.py
+++ b/pgtq/task.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Optional
 class Task:
     id: int
     call: str
+    queue_name: str
     args: Dict[str, Any]
     priority: int
     status: str


### PR DESCRIPTION
## Summary
- add queue scoping to tasks, notifications, and worker filtering
- persist worker task registrations in a shared registry table for controller discovery
- expose helper APIs to enqueue to specific queues and list registered tasks

## Testing
- `PYTHONPATH=. pytest -q`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691f8a0c996083219f1129602e7cd50b)